### PR TITLE
Create Example ManufacturingResult Events and Producer

### DIFF
--- a/base/kafka/kafka-message-example/COMMANDS.md
+++ b/base/kafka/kafka-message-example/COMMANDS.md
@@ -5,28 +5,54 @@ Namespace: `machine-monitoring`. Broker pod: `kafka-kafka-broker-0`. Topic: `man
 Run from repo root or from `base/kafka/kafka-message-example/` (adjust paths if needed).
 
 ---
+## 1. Consume messages (consumer)
 
-## 1. Send message (producer)
+It is a good idea to start the consumer first, so that you can see the message jump out when you use another terminal.
 
-Single line JSON (one message):
+Read all messages from the start (then Ctrl+C to stop), print key + value:
 
 ```bash
-cat base/kafka/kafka-message-example/manufacturing-result-eol-simple.json | kubectl exec -i -n machine-monitoring kafka-kafka-broker-0 -c kafka -- \
-  bin/kafka-console-producer.sh --bootstrap-server localhost:9092 --topic manufacturing-results-topic
+kubectl exec -it -n machine-monitoring kafka-kafka-broker-0 -c kafka -- \
+  bin/kafka-console-consumer.sh --bootstrap-server localhost:9092 --topic manufacturing-results-topic --from-beginning \
+  --property print.key=true --property key.separator=' | '
 ```
 
-From `base/kafka/kafka-message-example/`:
+Read only new messages (default, no `--from-beginning`), print key + value:
 
 ```bash
-cat manufacturing-result-eol-simple.json | kubectl exec -i -n machine-monitoring kafka-kafka-broker-0 -c kafka -- \
-  bin/kafka-console-producer.sh --bootstrap-server localhost:9092 --topic manufacturing-results-topic
+kubectl exec -it -n machine-monitoring kafka-kafka-broker-0 -c kafka -- \
+  bin/kafka-console-consumer.sh --bootstrap-server localhost:9092 --topic manufacturing-results-topic \
+  --property print.key=true --property key.separator=' | '
 ```
 
-Send and ensure last line is flushed (trailing newline):
+Read from start, print key + value, exit after 10 seconds (no -it):
 
 ```bash
-(cat base/kafka/kafka-message-example/manufacturing-result-eol-simple.json; echo) | kubectl exec -i -n machine-monitoring kafka-kafka-broker-0 -c kafka -- \
-  bin/kafka-console-producer.sh --bootstrap-server localhost:9092 --topic manufacturing-results-topic
+kubectl exec -n machine-monitoring kafka-kafka-broker-0 -c kafka -- \
+  bin/kafka-console-consumer.sh --bootstrap-server localhost:9092 --topic manufacturing-results-topic --from-beginning --timeout-ms 10000 \
+  --property print.key=true --property key.separator=' | '
+```
+
+## 1. Send message (producer, key/value format)
+
+Key = barcode, value = full JSON (same barcode -> same partition). Key and value are sent as `key<TAB>value`. Requires `jq` for method A.
+
+Method A - from repo root (extract key/value from JSON file):
+
+```bash
+KEY=$(jq -r '.barcode' base/kafka/kafka-message-example/manufacturing-result-eol-simple.json)
+VALUE=$(jq -c . base/kafka/kafka-message-example/manufacturing-result-eol-simple.json)
+printf '%s\t%s\n' "$KEY" "$VALUE" | kubectl exec -i -n machine-monitoring kafka-kafka-broker-0 -c kafka -- \
+  bin/kafka-console-producer.sh --bootstrap-server localhost:9092 --topic manufacturing-results-topic --property parse.key=true
+```
+
+Method B - from repo root (hardcoded one message, easy copy/paste):
+
+```bash
+kubectl exec -i -n machine-monitoring kafka-kafka-broker-0 -c kafka -- \
+  bin/kafka-console-producer.sh --bootstrap-server localhost:9092 --topic manufacturing-results-topic --property parse.key=true <<'EOF'
+SN-20250215-001	{"eventType":"manufacturing_simple","barcode":"SN-20250215-001","productCode":1001,"productSeq":42,"stationCode":201,"stationChannelNo":1,"result":1,"operator":"OP01","startTime":"2025-02-15T10:00:00Z","endTime":"2025-02-15T10:00:15Z"}
+EOF
 ```
 
 ---
@@ -50,25 +76,4 @@ kubectl exec -n machine-monitoring kafka-kafka-broker-0 -c kafka -- \
 
 ---
 
-## 3. Consume messages (consumer)
 
-Read all messages from the start (then Ctrl+C to stop):
-
-```bash
-kubectl exec -it -n machine-monitoring kafka-kafka-broker-0 -c kafka -- \
-  bin/kafka-console-consumer.sh --bootstrap-server localhost:9092 --topic manufacturing-results-topic --from-beginning
-```
-
-Read only new messages (default, no `--from-beginning`):
-
-```bash
-kubectl exec -it -n machine-monitoring kafka-kafka-broker-0 -c kafka -- \
-  bin/kafka-console-consumer.sh --bootstrap-server localhost:9092 --topic manufacturing-results-topic
-```
-
-Read from start, exit after 10 seconds (no -it):
-
-```bash
-kubectl exec -n machine-monitoring kafka-kafka-broker-0 -c kafka -- \
-  bin/kafka-console-consumer.sh --bootstrap-server localhost:9092 --topic manufacturing-results-topic --from-beginning --timeout-ms 10000
-```


### PR DESCRIPTION
Refactor COMMANDS.md to improve clarity and organization of Kafka message consumption and production commands. 

Current version of example kafka message is good enough, we just need to create way to send format, no code change is needed to create only these commands.